### PR TITLE
Update with correct number of shellcode bytes

### DIFF
--- a/payloads/x64-linux/linux_x64_binsh_execve.c
+++ b/payloads/x64-linux/linux_x64_binsh_execve.c
@@ -2,7 +2,7 @@
 
 /* 
 
-x64 execve /bin/sh -- 26 Bytes -- 7MAY017 -- icon
+x64 execve /bin/sh -- 28 Bytes -- 7MAY017 -- icon
 
 0:  31 c0                   xor    eax,eax
 2:  48 89 c2                mov    rdx,rax


### PR DESCRIPTION
The comment says that the shellcode is 26 bytes, but it is actually 28 bytes.